### PR TITLE
Don't rely on platform encoding being UTF-8

### DIFF
--- a/src/main/java/com/aylien/textapi/HttpSender.java
+++ b/src/main/java/com/aylien/textapi/HttpSender.java
@@ -63,7 +63,7 @@ public class HttpSender {
                     ? connection.getInputStream()
                     : connection.getErrorStream();
 
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
             StringBuilder response = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
The input stream reader that reads responses from the Aylien API
doesn’t specify a character encoding. This means it uses platform
encoding (specified by `-Dfile.encoding=XXXX`).

Everything works fine when the platform encoding is UTF-8, but when it
is not the UTF-8 responses from the API are incorrectly interpreted.
This fixes.